### PR TITLE
Updated DND Playground (DNDPage) with the styling of the current static "HomePage"

### DIFF
--- a/client/src/components/Column/Column.tsx
+++ b/client/src/components/Column/Column.tsx
@@ -3,24 +3,21 @@ import { Droppable } from "react-beautiful-dnd";
 import ColumnItem from "../ColumnItem";
 import { makeStyles } from "@material-ui/core/styles";
 
-
-interface ColumnInterface {
-  col:{
-  columnName:string;
-  orderedActions: string[];
-}
-}
+import React from 'react'
+import Paper from '@material-ui/core/Paper';
+import HelpDisplay from '../../components/HelpDisplay';
+import { Typography } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   column: {
-      display: "flex",
-      flexDirection:"column",
-      marginTop:8,
-      padding: '24px 0',
+    display: "flex",
+    flexDirection: "column",
+    marginTop: 8,
+    padding: '24px 0',
 
-    
+
   },
-  list:{
+  list: {
     backgroundColor: "#DAFEE2",
     borderRadius: 8,
     padding: 16,
@@ -29,41 +26,86 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
     marginTop: 8
   },
-  title:{
-    padding: "0 1rem",
-    margin:"2rem 0",
-    textAlign:"center",
-    color:"white",
-    
-  }
+  title: {
+    // padding: "0 1rem",
+    // margin: "2rem 0",
+    // textAlign: "center",
+    // color: "white",
+
+    textAlign: 'center',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    width: '8em',
+    fontSize: '1.5em',
+
+  },
+  brown_paper: {
+    padding: theme.spacing(2.3),
+    paddingBottom: theme.spacing(3),
+    paddingTop: theme.spacing(.5),
+    minHeight: '6vw',
+    textAlign: 'center',
+    backgroundColor: 'rgba(164,91,91,.53)',
+    borderRadius: '0px 0px 40px 40px',
+  },
+  green_paper: {
+    square: false,
+    backgroundColor: 'rgba(218,254,226)',
+    borderRadius: '40px 40px 0px 0px',
+    padding: theme.spacing(3, 2),
+    height: '1.5vw',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+  },
+  add_button: {
+    backgroundColor: '#2CF9AC',
+    width: '100%',
+  },
 }));
 
 
+interface ColumnInterface {
+  col: {
+    columnName: string;
+    orderedActions: string[];
+  }
+}
 
+function capitalizeFirstLetter(text: string) {
+  // From https://stackoverflow.com/questions/1026069/how-do-i-make-the-first-letter-of-a-string-uppercase-in-javascript
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
 
-const Column: React.FC<ColumnInterface> = ({col:{orderedActions,columnName }}) => {
-  const capColumnName=columnName.toUpperCase()
+const Column: React.FC<ColumnInterface> = ({ col: { orderedActions, columnName } }) => {
+  // const capColumnName = columnName.toUpperCase()
   const classes = useStyles();
-    return (
+  return (
+    <div>
+
+      <div style={{ float: 'right', paddingTop: '10px' }}>
+        <HelpDisplay helpMessage={'hello'} />
+      </div>
+
+      <Paper className={classes.green_paper} elevation={20} >
+        <Typography className={classes.title}> {capitalizeFirstLetter(columnName)} </Typography>
+      </Paper>
+
       <Droppable droppableId={columnName}>
         {(provided) => (
-          <div className={classes.column}>
-            <h2 className={classes.title}>{capColumnName}</h2>
-            <div 
-             className={classes.list}   
-             {...provided.droppableProps} ref={provided.innerRef}>
-     
-              {orderedActions&&orderedActions.map((orderedAction, index) => (
-            
+          <div >
+            <Paper className={classes.brown_paper}
+              {...provided.droppableProps} ref={provided.innerRef}>
+
+              {orderedActions && orderedActions.map((orderedAction, index) => (
                 <ColumnItem key={orderedAction} text={orderedAction} index={index} />
-             
               ))}
               {provided.placeholder}
-            </div>
+            </Paper>
           </div>
         )}
       </Droppable>
-    );
-  };
-  
-  export default Column;
+    </div>
+  );
+};
+
+export default Column;

--- a/client/src/components/ColumnItem/ColumnItem.tsx
+++ b/client/src/components/ColumnItem/ColumnItem.tsx
@@ -4,6 +4,12 @@ import { GET_ALL_ACTIONS } from '../../graphql/queries'
 import { useQuery } from '@apollo/client'
 import { makeStyles } from "@material-ui/core/styles";
 
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+import Toolbar from '@material-ui/core/Toolbar';
+import clsx from 'clsx';
+import Coin from '../CoinIcon/Coin';
 
 interface ItemInterface {
   text: string;
@@ -11,60 +17,99 @@ interface ItemInterface {
 }
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: .1,
+
+  },
+  palette: {
+    backgroundColor: '#C4C4C4'
+  },
   item: {
-    backgroundColor: "#eee",
     borderRadius: 4,
-    padding: "4px 8px",
     transition: "background-color .8s ease-out",
-    marginTop: 8,
+    marginTop: 20,
     "&:hover": {
-      backgroundColor: "pink",
-      transition: "background-color .1s ease-in"
+      backgroundColor: "#B2FFC3",
+      transition: "background-color 0s ease-in"
     }
   }
-   
+
 }));
 
 
-const ColumnItem: React.FC<ItemInterface> = ({ text,index  }) => {
-    const {loading,data, error}=useQuery(GET_ALL_ACTIONS)
-    const classes = useStyles();
-    if (typeof(data) == 'undefined') {
-      return (
-        <Draggable draggableId={text} index={index}>
+const ColumnItem: React.FC<ItemInterface> = ({ text, index }) => {
+  const { loading, data, error } = useQuery(GET_ALL_ACTIONS)
+  const classes = useStyles();
+  if (typeof (data) == 'undefined') {
+    return (
+      <Draggable draggableId={text} index={index}>
         {(provided) => (
-          <div
-            className={classes.item}
+          <Card className={clsx(classes.root, classes.palette, classes.item)}
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
           >
-            {text}
-          </div>
+            <CardContent>
+              <Typography variant="h5" component="h2" style={{ textAlign: 'left', width: '100%', fontSize: '1em' }}>
+                {text}
+              </Typography>
+            </CardContent>
+          </Card>
         )}
       </Draggable>
-      ); 
-    }else{
-    const fetchedText=data.getAllActions&&data.getAllActions.find((action:any)=>text===action["id"])
-   
+    );
+  } else {
+    const fetchedText = data.getAllActions && data.getAllActions.find((action: any) => text === action["id"])
+
     if (loading) return <h1>Loading...</h1>;
     if (error) return <h1>Something went wrong!</h1>;
     return (
       <Draggable draggableId={text} index={index}>
-      {(provided) => (
-        <div
-          className={classes.item}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-        >
-          {fetchedText["actionDescription"]} -------
-          {fetchedText["ecopoints"]}
-        </div>
-      )}
-    </Draggable>
+        {(provided) => (
+          <Card className={clsx(classes.root, classes.palette, classes.item)}
+
+            // className={classes.item}
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+          >
+            <CardContent>
+              <Toolbar >
+                <Typography variant="h5" component="h2" style={{ textAlign: 'left', width: '100%', fontSize: '1em' }}>
+                  {fetchedText["actionDescription"]}
+                </Typography>
+
+                <Typography variant="h5" component="h2" style={{ width: '30%', textAlign: 'right', fontSize: '1.5em' }}>
+
+                  <Toolbar style={{ float: 'right' }}>
+                    <Coin />
+                    {fetchedText["ecopoints"]}
+                  </Toolbar>
+                </Typography>
+
+              </Toolbar >
+            </CardContent>
+          </Card>
+        )
+        }
+      </Draggable >
+
+      // <Draggable draggableId={text} index={index}>
+      //   {(provided) => (
+
+      //     <div
+      //       className={classes.item}
+      //       ref={provided.innerRef}
+      //       {...provided.draggableProps}
+      //       {...provided.dragHandleProps}
+      //     >
+      //       {fetchedText["actionDescription"]} -------
+      //       {fetchedText["ecopoints"]}
+      //     </div>
+      //   )}
+      // </Draggable>
     );
   }
-  };
-  
-  export default ColumnItem;
+};
+
+export default ColumnItem;

--- a/client/src/components/ColumnList/ColumnList.tsx
+++ b/client/src/components/ColumnList/ColumnList.tsx
@@ -1,23 +1,17 @@
-import React,{useState} from 'react'
+import React, { useState } from 'react'
 import { GET_ALL_COLUMNS } from '../../graphql/queries'
 import { useQuery } from '@apollo/client'
-import { Paper } from '@material-ui/core'
-import { List } from '@material-ui/core'
 import Column from '../Column/Column'
 import { DragDropContext, DropResult } from 'react-beautiful-dnd'
 import { makeStyles } from "@material-ui/core/styles";
-
+import Grid from '@material-ui/core/Grid';
 
 const useStyles = makeStyles((theme) => ({
-    root: {
-        display: 'grid',
-        gridTemplateColumns: '1fr 1fr 1fr',
-        padding:'3rem 18rem',
-        gap: '8rem',
-        height:'50rem',
-        backgroundColor: "#113537",
-    },
-  }));
+  root: {
+    flexGrow: 1,
+    marginTop: '3%'
+  },
+}));
 
 
 
@@ -30,130 +24,129 @@ const useStyles = makeStyles((theme) => ({
 
 
 
-const ColumnList: React.FC=()=>{
- 
-    const {loading,data, error}=useQuery(GET_ALL_COLUMNS)
-    const [renderData, setRenderData] = React.useState<any[]>([])
-   
+const ColumnList: React.FC = () => {
 
-    React.useEffect(()=>{
-        if(!loading&&data){
-          let groupedData = getItemsByCategories(data.getAllColumns, "columnName");
-          setRenderData(groupedData)
-        }
-      },[loading,data])
-    
+  const { loading, data, error } = useQuery(GET_ALL_COLUMNS)
+  const [renderData, setRenderData] = React.useState<any[]>([])
 
-    const getItemsByCategories = (objectArray:any, property:any) => {
-        return objectArray.reduce((acc:any, obj:any) => {
-          const key = obj[property];
-          if (!acc[key]) {
-            acc[key] = {};
-          }
-          acc[key] = obj;
-          return acc;
-        }, {});
-      };
-    
-    
 
-    const onDragEnd = ({ source, destination }: DropResult) => {
-        // Make sure we have a valid destination
-        if (destination === undefined || destination === null) {return null}
-   
-        // Make sure we're actually moving the item
-        if (
-          source.droppableId === destination.droppableId &&
-          destination.index === source.index
-        )
-        {return null}
-     
-       
-        const sd:any=source.droppableId
-        const dd:any=destination.droppableId
-        const startColumnData= renderData[sd];
-        const endColumnData= renderData[dd];
-       
-        // If start is the same as end, we're in the same column
-        if (startColumnData === endColumnData) {
-         
-        //   Move the item within the list
-        //   Start by making a new list without the dragged item
-          const newList = startColumnData.orderedActions.filter(
-            (_: any, idx: number) => idx !== source.index
-          )
-        
-          // Then insert the item at the right location
-          newList.splice(destination.index, 0, startColumnData.orderedActions[source.index])
-    
-          // Then create a new copy of the column object
-          const newCol = {
-            columnName: startColumnData.columnName,
-            orderedActions: newList
-          }
-    
-          // Update the state
-          setRenderData(state => ({ ...state, [newCol.columnName]: newCol }))
-          return null
-        } else {
-           
-          // If start is different from end, we need to update multiple columns and ilter the start list 
-          const newStartList:any = startColumnData.orderedActions.filter(
-            (_: any, idx: number) => idx !== source.index
-          )
+  React.useEffect(() => {
+    if (!loading && data) {
+      let groupedData = getItemsByCategories(data.getAllColumns, "columnName");
+      setRenderData(groupedData)
+    }
+  }, [loading, data])
 
-        
-          // Create a new start column
-          const newStartCol = {
-            columnName: startColumnData.columnName,
-            orderedActions: newStartList
-          }
-       
-          const newEndList:any = Object.values(endColumnData.orderedActions)
-           
-          // Insert the item into the end list
 
-        newEndList.splice(destination.index, 0, startColumnData.orderedActions[source.index])
-    
-         
-          
-        //   Create a new end column
-          const newEndCol = {
-            columnName: endColumnData.columnName,
-            orderedActions: newEndList
-          }
-          console.log("newEndCol: ",newEndCol )
-    
-        //   Update the state
-          setRenderData((state:any)=>({
-            ...state,
-            [newStartCol.columnName]: newStartCol,
-            [newEndCol.columnName]: newEndCol
-          }))
-           
-        }
+  const getItemsByCategories = (objectArray: any, property: any) => {
+    return objectArray.reduce((acc: any, obj: any) => {
+      const key = obj[property];
+      if (!acc[key]) {
+        acc[key] = {};
       }
-    
+      acc[key] = obj;
+      return acc;
+    }, {});
+  };
 
-    const classes = useStyles();
-    // if (loading) return <h1>Loading...</h1>;
-    // if (error) return <h1>Something went wrong!</h1>;
-    
-    return(
-        <DragDropContext onDragEnd={onDragEnd}>
-            <Paper  >
-                <List className={classes.root} >
-                {
-                    Object.values(renderData).map((col:any)=>{
-                        return (
-                            <Column key={col.columnName} col={col} />
-                        )
-                    })
-                    }
-                </List>
-            </Paper> 
-        </DragDropContext>
-    )
+
+
+  const onDragEnd = ({ source, destination }: DropResult) => {
+    // Make sure we have a valid destination
+    if (destination === undefined || destination === null) { return null }
+
+    // Make sure we're actually moving the item
+    if (
+      source.droppableId === destination.droppableId &&
+      destination.index === source.index
+    ) { return null }
+
+
+    const sd: any = source.droppableId
+    const dd: any = destination.droppableId
+    const startColumnData = renderData[sd];
+    const endColumnData = renderData[dd];
+
+    // If start is the same as end, we're in the same column
+    if (startColumnData === endColumnData) {
+
+      //   Move the item within the list
+      //   Start by making a new list without the dragged item
+      const newList = startColumnData.orderedActions.filter(
+        (_: any, idx: number) => idx !== source.index
+      )
+
+      // Then insert the item at the right location
+      newList.splice(destination.index, 0, startColumnData.orderedActions[source.index])
+
+      // Then create a new copy of the column object
+      const newCol = {
+        columnName: startColumnData.columnName,
+        orderedActions: newList
+      }
+
+      // Update the state
+      setRenderData(state => ({ ...state, [newCol.columnName]: newCol }))
+      return null
+    } else {
+
+      // If start is different from end, we need to update multiple columns and ilter the start list 
+      const newStartList: any = startColumnData.orderedActions.filter(
+        (_: any, idx: number) => idx !== source.index
+      )
+
+
+      // Create a new start column
+      const newStartCol = {
+        columnName: startColumnData.columnName,
+        orderedActions: newStartList
+      }
+
+      const newEndList: any = Object.values(endColumnData.orderedActions)
+
+      // Insert the item into the end list
+
+      newEndList.splice(destination.index, 0, startColumnData.orderedActions[source.index])
+
+
+
+      //   Create a new end column
+      const newEndCol = {
+        columnName: endColumnData.columnName,
+        orderedActions: newEndList
+      }
+      console.log("newEndCol: ", newEndCol)
+
+      //   Update the state
+      setRenderData((state: any) => ({
+        ...state,
+        [newStartCol.columnName]: newStartCol,
+        [newEndCol.columnName]: newEndCol
+      }))
+
+    }
+  }
+
+
+  const classes = useStyles();
+  // if (loading) return <h1>Loading...</h1>;
+  // if (error) return <h1>Something went wrong!</h1>;
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Grid container spacing={3} justify="center">
+        {
+          Object.values(renderData).map((col: any) => {
+            return (
+              <Grid item xs={3} className={classes.root} >
+                <Column key={col.columnName} col={col} />
+              </Grid>
+            )
+          })
+        }
+      </Grid>
+    </DragDropContext>
+  )
 }
 
 export default ColumnList

--- a/client/src/components/HelpDisplay/HelpDisplay.tsx
+++ b/client/src/components/HelpDisplay/HelpDisplay.tsx
@@ -3,13 +3,21 @@ import Backdrop from '@material-ui/core/Backdrop';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         backdrop: {
             zIndex: theme.zIndex.drawer + 1,
+            backgroundColor: 'rgba(0,0,0,.8)',
             color: '#fff',
         },
+        // closeIcon: {
+        //     color: '#fff',
+        //     // position: 'absolute',
+        //     // top: '0px',
+        //     // right: '0px',
+        // }
     }),
 );
 
@@ -36,6 +44,9 @@ const HelpDisplay: React.FC<HelpDisplayInterface> = ({ helpMessage }) => {
             </IconButton>
 
             <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>
+                {/* <IconButton>
+                    <CloseIcon className='closeIcon'></CloseIcon>
+                </IconButton> */}
                 {helpMessage}
             </Backdrop>
         </div>

--- a/client/src/pages/DNDPage/DNDPage.tsx
+++ b/client/src/pages/DNDPage/DNDPage.tsx
@@ -1,43 +1,40 @@
 import React from 'react'
-
-import { Paper } from '@material-ui/core';
-import { makeStyles } from "@material-ui/core/styles";
-
+import NavBar from '../../components/NavBar';
 import ColumnList from '../../components/ColumnList';
+// import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    flexGrow: 2,
-    padding: 0,
-    margin: 0,
-    height: "40%",//100vh
-    backgroundColor: "#113537",
+// const useStyles = makeStyles((theme) => ({
+//   root: {
+//     display: 'flex',
+//     flexGrow: 1,
+//     // padding: 0,
+//     // margin: 0,
+//     // height: "40%",//100vh
+//     // backgroundColor: "#113537",
 
-  },
-  grid: {
-    marginTop: "1rem"
-  },
-  list: {
-    width: '50%',
-    margin: '1rem',
-  },
-  dndPaper: {
-    width: "100%",
-    backgroundColor: "red",
+//   },
+//   grid: {
+//     marginTop: "1rem"
+//   },
+//   list: {
+//     width: '50%',
+//     margin: '1rem',
+//   },
+//   dndPaper: {
+//     width: "100%",
+//     backgroundColor: "red",
 
-  },
+//   },
 
-}));
+// }));
 
 const DNDPage: React.FC = () => {
-  const classes = useStyles();
+  // const classes = useStyles();
   return (
-      <Paper className={classes.dndPaper}>
-        <div >
-          <ColumnList />
-        </div>
-      </Paper>
+    <div >
+      <NavBar loggedIn={true} />
+      <ColumnList />
+    </div>
   )
 }
 

--- a/server/src/Entities/Columns.ts
+++ b/server/src/Entities/Columns.ts
@@ -1,20 +1,19 @@
-import {Entity, Column, BaseEntity, ObjectIdColumn} from "typeorm"; 
-import {ObjectID} from "mongodb";
+import { Entity, Column, BaseEntity, ObjectIdColumn } from "typeorm";
+import { ObjectID } from "mongodb";
 
-@Entity()  
-export class Columns extends BaseEntity {  
+@Entity()
+export class Columns extends BaseEntity {
 
-   @ObjectIdColumn() 
-   id!: ObjectID; 
+   @ObjectIdColumn()
+   id!: ObjectID;
 
-   @Column() 
-   columnName!: string; 
+   @Column()
+   columnName!: string;
 
-   @Column("simple-array") 
-   orderedActions!: string[]; 
+   @Column("simple-array")
+   orderedActions!: string[];
 
 }
- 
 
 
- 
+


### PR DESCRIPTION
The current `HomePage` should later be replaced with `DNDPage`.

![image](https://user-images.githubusercontent.com/55062649/128448608-6fe23f5b-167d-453b-a6c5-3ba3332c4a22.png)

Missing features:
-Help Message is static. (from `helpDisplay`, the little question mark on each action list / column)

![image](https://user-images.githubusercontent.com/55062649/128448737-4b07b30c-a3c6-43a1-8cc8-e34073c7d2fb.png)

Previously, I had it passed in as a prop with each `ActionList`,
but 'Columns' are set up differently, so that will take a different approach.

Also tried to add the close button to the `helpDisplay`, but will complete that in a later commit.